### PR TITLE
Fix all_tests

### DIFF
--- a/docs/input_tables.md
+++ b/docs/input_tables.md
@@ -29,7 +29,7 @@ This table contains 1 row for every action. An action is a capital cost associat
 | ---- | ---- | ---- |
 | `action_id` | PK | |
 | `asset_type_id` | FK | The asset_type that this action applies to. Actions can only apply to a single asset_type. This keys into `asset_type_id` in the `asset_types` table. |
-| `cost` | | The cost of the action. This must be integer-valued. |
+| `cost` | | The cost of the action. This must be integer-valued. If computations in dollars and cents is desired just complete the computations in cents. Using floats will cause issues with float arithmetic. |
 | `replacement_flag` | | 1 if the action is a replacement; 0 otherwise. Replacements differ from other actions in that replacements update the year_built field of the asset. Once an asset is replaced, it can receive non-replacement actions that it has previously received again. |
 
 The following field is only reuqired when using the default neccesary actions function of `actions_by_age`:
@@ -59,7 +59,7 @@ This table contains 1 row for each year and the desired value for the backlog in
 | Field | Code | Description |
 | ---- | ---- | ---- |
 | `year` | | The year the budget is to be allocated for. This must contain a record for every year between, and including, (`start_year` + 1) and `end_year`. `start_year` is not included because no actions are performed the first year and instead a baseline is created. This must be integer-valued. |
-| `backlog` | | The value of the backlog desired for that year. This must be integer-valued. |
+| `backlog` | | The value of the backlog desired for that year. This must be integer-valued. If computations in dollars and cents is desired just complete the computations in cents. Using floats will cause issues with float arithmetic. |
 
 
 ## budgets
@@ -79,7 +79,7 @@ This table contains 1 row for each combination of budget and year
 | ---- | ---- | ---- |
 | `budget_id` | FK | Keys into the `budget_id` field of the `budgets` table | 
 | `year` | | The year the budget is to be allocated for. This must contain a record for every year between, and including, `start_year` and `end_year`. Note that not every `budget_id` must meet this requirement, but that there must be at least record for each year. This must be integer-valued. |
-| `budget` | | The maximum amount of money that can be allocated in a given year. This must be integer-valued |
+| `budget` | | The maximum amount of money that can be allocated in a given year. This must be integer-valued. If computations in dollars and cents is desired just complete the computations in cents. Using floats will cause issues with float arithmetic.|
 
 
 ## budget_actions

--- a/tests/all_tests.R
+++ b/tests/all_tests.R
@@ -6,9 +6,9 @@ library(here)
 library(testthat)
 
 # Load models
-source(here("models/unconstrained.R"))
-source(here("models/traditional.R"))
-source(here("models/backlog_seek.R"))
+source(here("R/unconstrained.R"))
+source(here("R/traditional.R"))
+source(here("R/backlog_seek.R"))
 
 # Get all unit tests
 unit_tests <- list.files(path = here("tests"), pattern = "^test.*\\.R$", full.names = TRUE)


### PR DESCRIPTION
- Fix `all_tests` to comply with changes made to make repo an R package
- Adds notes to docs on why it is best for costs to be integer valued